### PR TITLE
Fix typo in overview of pitch notations

### DIFF
--- a/src/User-Guide.md
+++ b/src/User-Guide.md
@@ -248,7 +248,7 @@ Here is an overview of all pitch notations:
 
 ```haskell
 sharpen c             == c sharp       == cs
-flatten d             == d flat        == ds
+flatten d             == d flat        == db
 (sharpen . sharpen) c == c doubleSharp == css
 (flatten . flatten) d == d doubleFlat  == dss
 ```


### PR DESCRIPTION
Now in the correct repo; based on [music-suite.github.io issue #3](https://github.com/music-suite/music-suite.github.io/pull/3).
